### PR TITLE
Support for AmpereOne family

### DIFF
--- a/src/advisor/constants/arch_specific_options.py
+++ b/src/advisor/constants/arch_specific_options.py
@@ -1,7 +1,16 @@
 """
 SPDX-License-Identifier: Apache-2.0
-Copyright (c) 2023, Ampere Computing LLC
+Copyright (c) 2024, Ampere Computing LLC
 """
 
-ARCH_SPECIFIC_OPTS = ['mmx', 'sse', 'sse2', 'sse3', 'ssse3', 'sse4', 'sse4a', 'sse4.1', 'sse4.2', 'avx', 'avx2', 'avx512f', 'avx512pf', 'avx512er', 'avx512cd', 'avx512vl', 'avx512bw', 'avx512dq', 'avx512ifma', 'avx512vbmi', 'sha', 'aes', 'pclmul', 'clflushopt', 'clwb', 'fsgsbase', 'ptwrite', 'rdrnd', 'f16c', 'fma', 'pconfig', 'wbnoinvd', 'fma4', 'prfchw', 'rdpid', 'prefetchwt1', 'rdseed', 'sgx', 'xop', 'lwp', '3dnow', '3dnowa', 'popcnt', 'abm', 'adx', 'bmi', 'bmi2', 'lzcnt', 'fxsr', 'xsave', 'xsaveopt', 'xsavec', 'xsaves', 'rtm', 'hle', 'tbm', 'mwaitx', 'clzero', 'pku', 'avx512vbmi2', 'avx512bf16', 'avx512fp16', 'gfni', 'vaes', 'waitpkg', 'vpclmulqdq', 'avx512bitalg', 'movdiri', 'movdir64b', 'enqcmd', 'uintr', 'tsxldtrk', 'avx512vpopcntdq', 'avx512vp2intersect', 'avx5124fmaps', 'avx512vnni', 'avxvnni', 'avx5124vnniw', 'cldemote', 'serialize', 'amx-tile', 'amx-int8', 'amx-bf16', 'hreset', 'kl', 'widekl', 'avxifma', 'avxvnniint8', 'avxneconvert', 'cmpccxadd', 'amx-fp16', 'prefetchi', 'raoint', 'amx-complex']
+X86_SPECIFIC_OPTS = ['mmx', 'sse', 'sse2', 'sse3', 'ssse3', 'sse4', 'sse4a', 'sse4.1', 'sse4.2', 'avx', 'avx2', 'avx512f', 'avx512pf', 'avx512er', 'avx512cd', 'avx512vl', 'avx512bw', 'avx512dq', 'avx512ifma', 'avx512vbmi', 'sha', 'aes', 'pclmul', 'clflushopt', 'clwb', 'fsgsbase', 'ptwrite', 'rdrnd', 'f16c', 'fma', 'pconfig', 'wbnoinvd', 'fma4', 'prfchw', 'rdpid', 'prefetchwt1', 'rdseed', 'sgx', 'xop', 'lwp', '3dnow', '3dnowa', 'popcnt', 'abm', 'adx', 'bmi', 'bmi2', 'lzcnt', 'fxsr', 'xsave', 'xsaveopt', 'xsavec', 'xsaves', 'rtm', 'hle', 'tbm', 'mwaitx', 'clzero', 'pku', 'avx512vbmi2', 'avx512bf16', 'avx512fp16', 'gfni', 'vaes', 'waitpkg', 'vpclmulqdq', 'avx512bitalg', 'movdiri', 'movdir64b', 'enqcmd', 'uintr', 'tsxldtrk', 'avx512vpopcntdq', 'avx512vp2intersect', 'avx5124fmaps', 'avx512vnni', 'avxvnni', 'avx5124vnniw', 'cldemote', 'serialize', 'amx-tile', 'amx-int8', 'amx-bf16', 'hreset', 'kl', 'widekl', 'avxifma', 'avxvnniint8', 'avxneconvert', 'cmpccxadd', 'amx-fp16', 'prefetchi', 'raoint', 'amx-complex']
 """Options that are not available on aarch64."""
+
+NEOVERSE_SPECIFIC_OPTS = ['neoverse-n1', 'neoverse-n2', 'neoverse-v1', 'neoverse-v2']
+"""Options for Arm Neoverse are not appropriate for AmpereOne family."""
+
+AMPEREONE_SPECIFIC_OPTS = ['ampere1', 'ampere1a', 'ampere1b']
+"""Options for AmpereOne family."""
+
+ARCH_SPECIFIC_IN_BUILD_FILES = ['meson.build', 'CMakeLists.txt', 'Makefile.in', 'Makefile.am', 'Makefile.arm64', 'Makefile.aarch64']
+"""Build files in aarch64 port dir can't be filter out as they might missing support for ampere1."""

--- a/src/advisor/constants/arch_specific_options.py
+++ b/src/advisor/constants/arch_specific_options.py
@@ -6,7 +6,7 @@ Copyright (c) 2024, Ampere Computing LLC
 X86_SPECIFIC_OPTS = ['mmx', 'sse', 'sse2', 'sse3', 'ssse3', 'sse4', 'sse4a', 'sse4.1', 'sse4.2', 'avx', 'avx2', 'avx512f', 'avx512pf', 'avx512er', 'avx512cd', 'avx512vl', 'avx512bw', 'avx512dq', 'avx512ifma', 'avx512vbmi', 'sha', 'aes', 'pclmul', 'clflushopt', 'clwb', 'fsgsbase', 'ptwrite', 'rdrnd', 'f16c', 'fma', 'pconfig', 'wbnoinvd', 'fma4', 'prfchw', 'rdpid', 'prefetchwt1', 'rdseed', 'sgx', 'xop', 'lwp', '3dnow', '3dnowa', 'popcnt', 'abm', 'adx', 'bmi', 'bmi2', 'lzcnt', 'fxsr', 'xsave', 'xsaveopt', 'xsavec', 'xsaves', 'rtm', 'hle', 'tbm', 'mwaitx', 'clzero', 'pku', 'avx512vbmi2', 'avx512bf16', 'avx512fp16', 'gfni', 'vaes', 'waitpkg', 'vpclmulqdq', 'avx512bitalg', 'movdiri', 'movdir64b', 'enqcmd', 'uintr', 'tsxldtrk', 'avx512vpopcntdq', 'avx512vp2intersect', 'avx5124fmaps', 'avx512vnni', 'avxvnni', 'avx5124vnniw', 'cldemote', 'serialize', 'amx-tile', 'amx-int8', 'amx-bf16', 'hreset', 'kl', 'widekl', 'avxifma', 'avxvnniint8', 'avxneconvert', 'cmpccxadd', 'amx-fp16', 'prefetchi', 'raoint', 'amx-complex']
 """Options that are not available on aarch64."""
 
-NEOVERSE_SPECIFIC_OPTS = ['neoverse-n1', 'neoverse-n2', 'neoverse-v1', 'neoverse-v2']
+NEOVERSE_SPECIFIC_OPTS = ['neoverse-']
 """Options for Arm Neoverse are not appropriate for AmpereOne family."""
 
 AMPEREONE_SPECIFIC_OPTS = ['ampere1', 'ampere1a', 'ampere1b']

--- a/src/advisor/constants/arch_strings.py
+++ b/src/advisor/constants/arch_strings.py
@@ -19,11 +19,11 @@ SPDX-License-Identifier: Apache-2.0
 AARCH64_ARCHS = ['arm', 'aarch64', 'arm64', 'neon', 'sve']
 
 NON_AARCH64_ARCHS = ['alpha', 'altivec', 'amd64', 'avx', 'avx512', 'hppa',
-                     'i386', 'i586', 'i686', 'ia64', 'intel', 'intel64', 'ix86',
-                     'm68k', 'microblaze', 'mips', 'nios2', 'otherarch', 'power',
-                     'powerpc', 'powerpc32', 'powerpc64', 'ppc', 'ppc64',
-                     'ppc64le', 's390', 'sh', 'sparc', 'sse', 'sse2', 'sse3',
-                     'tile', 'x64', 'x86', 'x86_64']
+                     'i386', 'i586', 'i686', 'ia64', 'intel', 'intel64', 'ix86', 'loongarch64',
+                     'm68k', 'microblaze', 'mips', 'nios2', 'otherarch', 'penryn', 'power',
+                     'powerpc', 'powerpc32', 'powerpc64', 'ppc', 'ppc64', 'ppc64le', 'riscv64',
+                     'sandybridge', 's390', 'sh', 'sifive_x280', 'sparc', 'sse', 'sse2', 'sse3',
+                     'tile', 'x64', 'x86', 'x86_64', 'zarch', 'zen', 'zen2', 'zen3']
 
 COMPILERS = ['clang', 'cray', 'flang', 'gcc', 'gfortran', 'gnuc', 'gnug', 'ibmcpp', 'ibmxl', 'icc', 'ifort',
              'intel', 'intel_compiler', 'llvm', 'pathscale', 'pgi', 'pgic', 'sunpro', 'xlc', 'xlf']

--- a/src/advisor/helpers/find_port.py
+++ b/src/advisor/helpers/find_port.py
@@ -42,7 +42,7 @@ def port_filenames(filename):
                 filename = ''.join(parts[:i]) + \
                     arm_arch + ''.join(parts[(i + 1):])
                 ret.append(filename)
-        elif part in AARCH64_ARCHS:
+        elif part in AARCH64_ARCHS and filename not in ARCH_SPECIFIC_IN_BUILD_FILES:
             ret.append(filename)
     return ret
 

--- a/src/advisor/helpers/find_port.py
+++ b/src/advisor/helpers/find_port.py
@@ -19,6 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 import os
 import re
 from ..constants.arch_strings import AARCH64_ARCHS, NON_AARCH64_ARCHS
+from ..constants.arch_specific_options import ARCH_SPECIFIC_IN_BUILD_FILES
 
 
 def port_filenames(filename):
@@ -105,7 +106,7 @@ def find_port_file(filename, other_files, other_files_dirs=None):
         for file in other_files:
             other_files_dirs.add(os.path.dirname(file))
     port_dir = find_port_dir(head, other_files_dirs)
-    if port_dir:
+    if port_dir and tail not in ARCH_SPECIFIC_IN_BUILD_FILES:
         return os.path.join(port_dir, tail)
     return None
 

--- a/src/advisor/reports/issues/arch_specific_build_option_issue.py
+++ b/src/advisor/reports/issues/arch_specific_build_option_issue.py
@@ -1,10 +1,11 @@
 """
 SPDX-License-Identifier: Apache-2.0
-Copyright (c) 2023, Ampere Computing LLC
+Copyright (c) 2024, Ampere Computing LLC
 """
 
 from .issue import Issue
 from ..localization import _
+from ..report_item import ReportItem
 
 
 class ArchSpecificBuildOptionIssue(Issue):
@@ -13,3 +14,18 @@ class ArchSpecificBuildOptionIssue(Issue):
             opt_name
         super().__init__(description=description, filename=filename,
                          lineno=lineno)
+        
+class NeoverseSpecificBuildOptionIssue(Issue):
+    def __init__(self, filename, lineno, opt_name, opt_value):
+        description = (_("neoverse-specific build option may not appropriate for AmpereOne: "
+                         "-m%s=%s, see https://amperecomputing.com/tutorials/gcc-guide-ampere-processors for more details.") \
+                         % (opt_name, opt_value))
+        super().__init__(description=description, filename=filename,
+                         lineno=lineno, item_type=ReportItem.NEUTRAL)
+        
+class AmpereoneSpecificBuildOptionIssue(Issue):
+    def __init__(self, filename, lineno):
+        description = (_("Missing build option for AmpereOne, see "
+                         "https://amperecomputing.com/tutorials/gcc-guide-ampere-processors for more details."))
+        super().__init__(description=description, filename=filename,
+                         lineno=lineno, item_type=ReportItem.NEUTRAL)

--- a/src/advisor/scanners/meson_scanner.py
+++ b/src/advisor/scanners/meson_scanner.py
@@ -26,7 +26,7 @@ class MesonScanner(Scanner):
 
     X86_SPECIFIC_OPTS_RE_PROG = re.compile(r'-m(%s)' %
                                             '|'.join([(r'%s\b' % x) for x in X86_SPECIFIC_OPTS]))
-    ARCH_SPECIFIC_LIBS_RE_PROG = re.compile(r'(?:find_package|find_library)\((%s)' %
+    ARCH_SPECIFIC_LIBS_RE_PROG = re.compile(r'(?:find_library)\(\'(%s)' %
                                             '|'.join([(r'%s\b' % x) for x in ARCH_SPECIFIC_LIBS]))
     NEOVERSE_SPECIFIC_OPTS_RE_PROG = re.compile(r'-m(cpu|tune)=(%s)' %
                                             '|'.join([(r'%s\b' % x) for x in NEOVERSE_SPECIFIC_OPTS]))

--- a/src/advisor/scanners/meson_scanner.py
+++ b/src/advisor/scanners/meson_scanner.py
@@ -19,10 +19,10 @@ from ..reports.issues.define_other_arch_issue import DefineOtherArchIssue
 from .scanner import Scanner
 
 
-class CMakeScanner(Scanner):
-    """Scanner that scans CMake"""
+class MesonScanner(Scanner):
+    """Scanner that scans Meson builds"""
 
-    CMAKE_NAMES = ['CMakeLists.txt']
+    MESON_NAMES = ['meson.build']
 
     X86_SPECIFIC_OPTS_RE_PROG = re.compile(r'-m(%s)' %
                                             '|'.join([(r'%s\b' % x) for x in X86_SPECIFIC_OPTS]))
@@ -32,19 +32,13 @@ class CMakeScanner(Scanner):
                                             '|'.join([(r'%s\b' % x) for x in NEOVERSE_SPECIFIC_OPTS]))
     AMPEREONE_SPECIFIC_OPTS_RE_PROG = re.compile(r'-m(cpu|tune)=(%s)' %
                                             '|'.join([(r'%s\b' % x) for x in AMPEREONE_SPECIFIC_OPTS]))
-    OTHER_ARCH_CPU_LINE_RE_PROG = re.compile(r'(?:CMAKE_SYSTEM_PROCESSOR).*(%s)' %
-                                  '|'.join(NON_AARCH64_ARCHS))
-    AARCH64_CPU_LINE_RE_PROG = re.compile(r'(?:CMAKE_SYSTEM_PROCESSOR).*(%s)' %
-                                  '|'.join(AARCH64_ARCHS))
 
     def accepts_file(self, filename):
         basename = os.path.basename(filename)
-        return basename in CMakeScanner.CMAKE_NAMES
+        return basename in MesonScanner.MESON_NAMES
 
     def scan_file_object(self, filename, file, report):
         continuation_parser = ContinuationParser()
-        other_arch_cpu_condition = None
-        seen_aarch64_cpu_condition = False
         seen_neoverse_build_flag = False
         seen_ampere1_build_flag = False
 
@@ -54,35 +48,25 @@ class CMakeScanner(Scanner):
             if not line:
                 continue
 
-            match = CMakeScanner.ARCH_SPECIFIC_LIBS_RE_PROG.search(line)
+            match = MesonScanner.ARCH_SPECIFIC_LIBS_RE_PROG.search(line)
             if match:
                 lib_name = match.group(1)
                 report.add_issue(ArchSpecificLibraryIssue(
                     filename, lineno + 1, lib_name))
-            match = CMakeScanner.X86_SPECIFIC_OPTS_RE_PROG.search(line)
+            match = MesonScanner.X86_SPECIFIC_OPTS_RE_PROG.search(line)
             if match:
                 opt_name = match.group(1)
                 report.add_issue(ArchSpecificBuildOptionIssue(
                     filename, lineno + 1, opt_name))
-            match = CMakeScanner.NEOVERSE_SPECIFIC_OPTS_RE_PROG.search(line)
+            match = MesonScanner.NEOVERSE_SPECIFIC_OPTS_RE_PROG.search(line)
             if match:
-                seen_aarch64_cpu_condition = True
                 seen_neoverse_build_flag = True
                 opt_name = match.group(1)
                 opt_value = match.group(2)
                 report.add_issue(NeoverseSpecificBuildOptionIssue(
                     filename, lineno + 1, opt_name, opt_value))
-            match = CMakeScanner.AMPEREONE_SPECIFIC_OPTS_RE_PROG.search(line)
+            match = MesonScanner.AMPEREONE_SPECIFIC_OPTS_RE_PROG.search(line)
             if match:
-                seen_aarch64_cpu_condition = True
                 seen_ampere1_build_flag = True
-            match = CMakeScanner.OTHER_ARCH_CPU_LINE_RE_PROG.search(line)
-            if match:
-                other_arch_cpu_condition = line
-            match = CMakeScanner.AARCH64_CPU_LINE_RE_PROG.search(line)
-            if match:
-                seen_aarch64_cpu_condition = True
-        if other_arch_cpu_condition and not seen_aarch64_cpu_condition:
-            report.add_issue(DefineOtherArchIssue(filename, lineno + 1, other_arch_cpu_condition))
         if seen_neoverse_build_flag and not seen_ampere1_build_flag:
             report.add_issue(AmpereoneSpecificBuildOptionIssue(filename, lineno + 1))

--- a/src/advisor/scanners/scanner.py
+++ b/src/advisor/scanners/scanner.py
@@ -19,7 +19,6 @@ SPDX-License-Identifier: Apache-2.0
 import os
 import traceback
 from ..reports.error import Error
-from concurrent.futures import ThreadPoolExecutor, as_completed
 
 
 class Scanner:
@@ -95,18 +94,6 @@ class Scanner:
         """
         pass
 
-    def scan_file_entry(self, filename, report, progress_callback=None):
-        """Entry function for multithread filesystem tree scanning.
-        Args:
-            file (str): The file to scan.
-            report (Report): Report to add issues to.
-            progress_callback (function): Optional callback called with file names.
-        """
-        if not Scanner._is_vcs_directory(filename) and self.accepts_file(filename):
-            if progress_callback:
-                progress_callback(filename)
-            self.scan_file(filename, report)
-
     def scan_tree(self, root, report, progress_callback=None):
         """Scans the filesysem tree starting at root for potential porting issues.
 
@@ -115,18 +102,13 @@ class Scanner:
             report (Report): Report to add issues to.
             progress_callback (function): Optional callback called with file names.
         """
-        with ThreadPoolExecutor(4) as executor:
-            for dirName, _, fileList in os.walk(root):
-                files = []
-                reports = []
-                p_cb = []
-                runs = []
-                for fname in fileList:
-                    path = os.path.join(dirName, fname)
-                    files.append(path)
-                    reports.append(report)
-                    p_cb.append(progress_callback)
-                runs.append(executor.map(self.scan_file_entry, files, reports, p_cb))
+        for dirName, _, fileList in os.walk(root):
+            for fname in fileList:
+                path = os.path.join(dirName, fname)
+                if not Scanner._is_vcs_directory(path) and self.accepts_file(path):
+                    if progress_callback:
+                        progress_callback(path)
+                    self.scan_file(path, report)
 
     @staticmethod
     def _is_vcs_directory(path):

--- a/src/advisor/scanners/scanners.py
+++ b/src/advisor/scanners/scanners.py
@@ -26,6 +26,7 @@ from .go_scanner import GoScanner
 from .java_scanner import JavaScanner
 from .makefile_scanner import MakefileScanner
 from .cmake_scanner import CMakeScanner
+from .meson_scanner import MesonScanner
 from .python_scanner import PythonScanner
 from .source_scanner import SourceScanner
 
@@ -49,7 +50,8 @@ class Scanners:
                         AsmSourceScanner(),
                         ConfigGuessScanner(),
                         MakefileScanner(),
-                        CMakeScanner()]
+                        CMakeScanner(),
+                        MesonScanner()]
         self.filters = [PortFilter()] if filter_ported_code else []
         self.filters += [IssueTypeFilter(issue_type_config),
                          TargetOsFilter(),

--- a/unittest/test_cmake_scanner.py
+++ b/unittest/test_cmake_scanner.py
@@ -74,3 +74,15 @@ class TestCMakeScanner(unittest.TestCase):
         cmake_scanner.scan_file_object(
             'CMakeLists.txt', io_object, report)
         self.assertEqual(len(report.issues), 1)
+
+    def test_neoverse_specific_opts_line_re(self):
+        match = CMakeScanner.NEOVERSE_SPECIFIC_OPTS_RE_PROG.search('ADD_CXX_FLAGS("-mtune=ampere1a")')
+        self.assertIsNone(match)
+        match = CMakeScanner.NEOVERSE_SPECIFIC_OPTS_RE_PROG.search('ADD_CXX_FLAGS("-mtune=neoverse-n2")')
+        self.assertIsNotNone(match)
+
+    def test_ampereone_specific_opts_line_re(self):
+        match = CMakeScanner.AMPEREONE_SPECIFIC_OPTS_RE_PROG.search('ADD_CXX_FLAGS("-mcpu=neoverse-v2")')
+        self.assertIsNone(match)
+        match = CMakeScanner.AMPEREONE_SPECIFIC_OPTS_RE_PROG.search('ADD_CXX_FLAGS("-mcpu=ampere1b")')
+        self.assertIsNotNone(match)

--- a/unittest/test_makefile_scanner.py
+++ b/unittest/test_makefile_scanner.py
@@ -300,3 +300,15 @@ class TestMakefileScanner(unittest.TestCase):
         makefile_scanner.scan_file_object(
             'Makefile', io_object, report)
         self.assertEqual(len(report.issues), 1)
+
+    def test_neoverse_specific_opts_line_re(self):
+        match = MakefileScanner.NEOVERSE_SPECIFIC_OPTS_RE_PROG.search('CFLAGS = -mtune=ampere1a')
+        self.assertIsNone(match)
+        match = MakefileScanner.NEOVERSE_SPECIFIC_OPTS_RE_PROG.search('CFLAGS = -mtune=neoverse-n2')
+        self.assertIsNotNone(match)
+
+    def test_ampereone_specific_opts_line_re(self):
+        match = MakefileScanner.AMPEREONE_SPECIFIC_OPTS_RE_PROG.search('CFLAGS = -mcpu=neoverse-v2')
+        self.assertIsNone(match)
+        match = MakefileScanner.AMPEREONE_SPECIFIC_OPTS_RE_PROG.search('CFLAGS = -mcpu=ampere1b')
+        self.assertIsNotNone(match)

--- a/unittest/test_meson_scanner.py
+++ b/unittest/test_meson_scanner.py
@@ -1,6 +1,6 @@
 """
 SPDX-License-Identifier: Apache-2.0
-Copyright (c) 2023, Ampere Computing LLC
+Copyright (c) 2024, Ampere Computing LLC
 """
 
 import io

--- a/unittest/test_meson_scanner.py
+++ b/unittest/test_meson_scanner.py
@@ -1,0 +1,70 @@
+"""
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2023, Ampere Computing LLC
+"""
+
+import io
+import unittest
+from src.advisor.reports.report import Report
+from src.advisor.scanners.meson_scanner import MesonScanner
+
+
+class TestMesonScanner(unittest.TestCase):
+    def test_accepts_file(self):
+        meson_scanner = MesonScanner()
+        self.assertFalse(meson_scanner.accepts_file('test'))
+        self.assertTrue(meson_scanner.accepts_file('meson.build'))
+
+    def test_scan_file_object(self):
+        meson_scanner = MesonScanner()
+        report = Report('/root')
+        io_object = io.StringIO('xxx')
+        meson_scanner.scan_file_object(
+            'meson.build', io_object, report)
+        self.assertEqual(len(report.issues), 0)
+
+
+    def test_arch_specific_libs_re(self):
+        match = MesonScanner.ARCH_SPECIFIC_LIBS_RE_PROG.search("cc.find_library('foo')")
+        self.assertIsNone(match)
+        match = MesonScanner.ARCH_SPECIFIC_LIBS_RE_PROG.search("cc.find_library('otherarch')")
+        self.assertIsNotNone(match)
+        self.assertEqual(match.group(1), "otherarch")
+
+    def test_arch_specific_libs(self):
+        meson_scanner = MesonScanner()
+        report = Report('/root')
+        io_object = io.StringIO("cc.find_library('otherarch')")
+        meson_scanner.scan_file_object(
+            'meson.build', io_object, report)
+        self.assertEqual(len(report.issues), 1)
+
+    def test_neoverse_specific_opts_line_re(self):
+        match = MesonScanner.NEOVERSE_SPECIFIC_OPTS_RE_PROG.search("'compiler_options':  ['-mcpu=ampere1a'],")
+        self.assertIsNone(match)
+        match = MesonScanner.NEOVERSE_SPECIFIC_OPTS_RE_PROG.search("'compiler_options':  ['-mcpu=neoverse-n2'],")
+        self.assertIsNotNone(match)
+
+    def test_ampereone_specific_opts_line_re(self):
+        match = MesonScanner.AMPEREONE_SPECIFIC_OPTS_RE_PROG.search("'compiler_options':  ['-mcpu=neoverse-n2'],")
+        self.assertIsNone(match)
+        match = MesonScanner.AMPEREONE_SPECIFIC_OPTS_RE_PROG.search("'compiler_options':  ['-mcpu=ampere1a'],")
+        self.assertIsNotNone(match)
+
+    def test_neoverse_specific_opts_line(self):
+        meson_scanner = MesonScanner()
+
+        report = Report('/root')
+        io_object = io.StringIO("'compiler_options':  ['-mcpu=neoverse-n2'],")
+        meson_scanner.scan_file_object(
+            'meson.build', io_object, report)
+        # Should report 2 issues, one for neoverse flag indication, another for ampereone flag missing.
+        self.assertEqual(len(report.issues), 2)
+
+        report = Report('/root')
+        io_object = io.StringIO("'compiler_options':  ['-mcpu=ampere1a'],\n'compiler_options':  ['-mtune=ampere1a'],\n'compiler_options':  ['-mcpu=neoverse-v2'],\n'compiler_options':  ['-mtune=neoverse-v2'],\n")
+        meson_scanner.scan_file_object(
+            'meson.build', io_object, report)
+        self.assertEqual(len(report.issues), 2)
+
+


### PR DESCRIPTION
#### Support for AmpereOne family
Ampere's newest processor, AmpereOne, has architecture-specific build options to improve performance through better code generation. This PR is aimed to detect software built for the Arm Neoverse series of processors and recommend options for AmpereOne support.

#### Add detection for meson build files
This PR support detects meson build files for missing AmpereOne support.

#### Other changes
Extend other arch list with loongarch64, riscv64, sandybridge, zen, etc to reduce noise.
UT cases extended.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.